### PR TITLE
feat: implement sequence helper function in array

### DIFF
--- a/array.ts
+++ b/array.ts
@@ -3,7 +3,7 @@ import type * as TC from "./type_classes.ts";
 import type { Fn, Predicate } from "./types.ts";
 
 import * as O from "./option.ts";
-import { pipe } from "./fns.ts";
+import { identity, pipe } from "./fns.ts";
 
 /*******************************************************************************
  * Types
@@ -307,6 +307,13 @@ export const {
 } = IndexedTraversable;
 
 export const { filter } = Filterable;
+
+export const createSequence = <U extends HKT.URIS>(A: TC.Applicative<U>) => {
+  const _sequence = pipe(A.map(identity), traverse(A));
+  return _sequence as unknown as <A, B, C, D>(
+    tas: HKT.Kind<U, [A, B, C, D]>[],
+  ) => HKT.Kind<U, [A[], B, C, D]>;
+};
 
 export const lookup = (i: number) =>
   <A>(as: readonly A[]): O.Option<A> =>

--- a/array.ts
+++ b/array.ts
@@ -311,8 +311,8 @@ export const { filter } = Filterable;
 export const createSequence = <U extends HKT.URIS>(A: TC.Applicative<U>) => {
   const _sequence = pipe(A.map(identity), traverse(A));
   return _sequence as unknown as <A, B, C, D>(
-    tas: HKT.Kind<U, [A, B, C, D]>[],
-  ) => HKT.Kind<U, [A[], B, C, D]>;
+    tas: readonly HKT.Kind<U, [A, B, C, D]>[],
+  ) => HKT.Kind<U, [readonly A[], B, C, D]>;
 };
 
 export const lookup = (i: number) =>

--- a/examples/sequence.ts
+++ b/examples/sequence.ts
@@ -1,0 +1,8 @@
+import * as A from "../array.ts";
+import * as O from "../option.ts";
+import { identity, pipe } from "../fns.ts";
+
+const sequence = A.createSequence(O.Applicative);
+
+console.log(sequence([O.some(1), O.some(2)])); // { tag: "Some", value: [ 1, 2 ] }
+console.log(sequence([O.none, O.some(2)])); // { tag: "None" }

--- a/testing/array.test.ts
+++ b/testing/array.test.ts
@@ -231,6 +231,15 @@ Deno.test("Array filter", () => {
   assertEquals(pipe([1, 2, 3], A.filter((n) => n > 1)), [2, 3]);
 });
 
+Deno.test("Array createSequence", () => {
+  const sequence = A.createSequence(A.Applicative);
+  assertEquals(sequence([]), [[]]);
+  assertEquals(sequence([[1]]), [[1]]);
+  assertEquals(sequence([[], [1]]), []);
+  assertEquals(sequence([[1], [2], [3]]), [[1, 2, 3]]);
+  assertEquals(sequence([[1, 2], [3, 4]]), [[1, 3], [1, 4], [2, 3], [2, 4]]);
+});
+
 Deno.test("Array lookup", () => {
   assertEquals(pipe([1, 2, 3], A.lookup(1)), O.some(2));
   assertEquals(pipe([], A.lookup(1)), O.none);


### PR DESCRIPTION
TypeScript still has issues inferring the correct type for:

      import * as A from "https://deno.land/x/fun/array.ts";
      import * as O from "https://deno.land/x/fun/option.ts";
      import { identity, pipe } from "https://deno.land/x/fun/fns.ts";

      const sequence = pipe(
        O.map(identity),
        A.traverse(O.Applicative)
      )

Since there is a call for an easy sequence (not over a tuple) of arrays
of various ADTs this commit implements a createSequence function in
array.ts.

      import * as A from "../array.ts";
      import * as O from "../option.ts";
      import { identity, pipe } from "../fns.ts";

      const sequence = A.createSequence(O.Applicative);

      console.log(sequence([O.some(1), O.some(2)])); // { tag: "Some", value: [ 1, 2 ] }
      console.log(sequence([O.none, O.some(2)])); // { tag: "None" }

While it is not used to create an adt specific sequence function for
every ADT it's possible that it might be used thusly in the future.

Fixes #7 