### PR TITLE
Fix: examples/fetch_archives.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,23 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+All notable changes to this project will be documented in this file. See
+[standard-version](https://github.com/conventional-changelog/standard-version)
+for commit guidelines.
 
 ## [1.0.0](https://github.com/nullpub/fun/compare/v0.0.0...v1.0.0) (2021-05-02)
 
-
 ### Features
 
-* decoder schemable tests complete ([ed229f0](https://github.com/nullpub/fun/commit/ed229f08dbc6d399bcde0064c39c9393cd770d19))
-* minor documentation, readme, and api finale ([3df40d4](https://github.com/nullpub/fun/commit/3df40d44a9f5b8cdfe28c3cb5df6cc2650821fef))
-* push test completion to 100% ([5561cbc](https://github.com/nullpub/fun/commit/5561cbc7a83292cfcc2a0a31f2059c87ded7abcc))
+- decoder schemable tests complete
+  ([ed229f0](https://github.com/nullpub/fun/commit/ed229f08dbc6d399bcde0064c39c9393cd770d19))
+- minor documentation, readme, and api finale
+  ([3df40d4](https://github.com/nullpub/fun/commit/3df40d44a9f5b8cdfe28c3cb5df6cc2650821fef))
+- push test completion to 100%
+  ([5561cbc](https://github.com/nullpub/fun/commit/5561cbc7a83292cfcc2a0a31f2059c87ded7abcc))
 
 ## 0.0.0 (2021-04-22)
 
-
 ### Features
 
-* initial migration from hkts ([d939ca4](https://github.com/nullpub/fun/commit/d939ca4af16ebf8a4456f7a6a7ff8d5e0f2cf07c))
+- initial migration from hkts
+  ([d939ca4](https://github.com/nullpub/fun/commit/d939ca4af16ebf8a4456f7a6a7ff8d5e0f2cf07c))

--- a/README.md
+++ b/README.md
@@ -1,28 +1,70 @@
 # functional [![Coverage Status](https://coveralls.io/repos/github/nullpub/fun/badge.svg?branch=main)](https://coveralls.io/github/nullpub/fun?branch=main)
 
-functional is a set of utility modules in the vein of [Ramda](https://ramdajs.com/) and [fp-ts](https://gcanti.github.io/fp-ts/). It uses a [lightweight higher kinded type encoding](https://github.com/nullpub/fun/blob/main/hkt.ts) to implement [type classes](https://github.com/nullpub/fun/blob/main/type_classes.ts) such as Functor, Monad, and Traversable. Originally, it followed the [static-land](https://github.com/fantasyland/static-land/blob/master/docs/spec.md) specification for these modules, but has since diverged and settled on a curried form of those same module definitions. It contains many common algebraic types such as [Option](https://github.com/nullpub/fun/blob/main/option.ts), [Either](https://github.com/nullpub/fun/blob/main/either.ts), and other tools such as [Lenses](https://github.com/nullpub/fun/blob/main/optics/lens.ts) and [Schemables](https://github.com/nullpub/fun/blob/main/schemable/schemable.ts).
+functional is a set of utility modules in the vein of
+[Ramda](https://ramdajs.com/) and [fp-ts](https://gcanti.github.io/fp-ts/). It
+uses a
+[lightweight higher kinded type encoding](https://github.com/nullpub/fun/blob/main/hkt.ts)
+to implement
+[type classes](https://github.com/nullpub/fun/blob/main/type_classes.ts) such as
+Functor, Monad, and Traversable. Originally, it followed the
+[static-land](https://github.com/fantasyland/static-land/blob/master/docs/spec.md)
+specification for these modules, but has since diverged and settled on a curried
+form of those same module definitions. It contains many common algebraic types
+such as [Option](https://github.com/nullpub/fun/blob/main/option.ts),
+[Either](https://github.com/nullpub/fun/blob/main/either.ts), and other tools
+such as [Lenses](https://github.com/nullpub/fun/blob/main/optics/lens.ts) and
+[Schemables](https://github.com/nullpub/fun/blob/main/schemable/schemable.ts).
 
 The primary goals of functional are to be:
 
-- **Pragmatic**: The API surface of functional should favor ease-of-use and consistency over cleverness or purity. This project is ultimately for getting work done.
-- **Understandable**: The HKT and Type Class implementations are meant to be as simple as possible so their logic can be easily audited.
-- **Performant**: Once the first two goals are satisfied, the long term changes within functional are likely going to be beneath the API surface and aimed at speeding things up where possible.
+- **Pragmatic**: The API surface of functional should favor ease-of-use and
+  consistency over cleverness or purity. This project is ultimately for getting
+  work done.
+- **Understandable**: The HKT and Type Class implementations are meant to be as
+  simple as possible so their logic can be easily audited.
+- **Performant**: Once the first two goals are satisfied, the long term changes
+  within functional are likely going to be beneath the API surface and aimed at
+  speeding things up where possible.
 
 Some non-goals of functional are:
 
-- To be an exact port of fp-ts. Many changes have been implemented throughout functional that diverge sharply from fp-ts, this is often on purpose.
+- To be an exact port of fp-ts. Many changes have been implemented throughout
+  functional that diverge sharply from fp-ts, this is often on purpose.
 
 ## History
 
-functional started as an exploratory project in late 2020 to learn more about higher kinded type implementations in TypeScript and to assess how much effort it would take to port fp-ts to a Deno-native format. Through that process it became clear that the things I had learned could serve as both a useful tool and as a learning resource in and of itself. At various times functional has used multiple hkt encodings, type class definitions, and implementation methods. Some of the key history moments of functional are in the hkts history. Specifically, the [hkts implementation](https://github.com/nullpub/hkts/commit/684e3e56c2d6ae7313fc70c2f35a942c8abad8d8) in the initial commit and the last [major type system rewrite](https://github.com/nullpub/hkts/tree/32ddaa0ddde4d437807a66e914c7854867ed847d) might be interesting. Now, however, the API for version 1.0.0 is set and will only change between major versions (which should be extremely rare).
+functional started as an exploratory project in late 2020 to learn more about
+higher kinded type implementations in TypeScript and to assess how much effort
+it would take to port fp-ts to a Deno-native format. Through that process it
+became clear that the things I had learned could serve as both a useful tool and
+as a learning resource in and of itself. At various times functional has used
+multiple hkt encodings, type class definitions, and implementation methods. Some
+of the key history moments of functional are in the hkts history. Specifically,
+the
+[hkts implementation](https://github.com/nullpub/hkts/commit/684e3e56c2d6ae7313fc70c2f35a942c8abad8d8)
+in the initial commit and the last
+[major type system rewrite](https://github.com/nullpub/hkts/tree/32ddaa0ddde4d437807a66e914c7854867ed847d)
+might be interesting. Now, however, the API for version 1.0.0 is set and will
+only change between major versions (which should be extremely rare).
 
-This project is incredibly indebted to [gcanti](https://github.com/gcanti), [pelotom](https://github.com/pelotom), and the TypeScript community at large. There is nothing new in this project, it's all a reimaginings of ideas that already existed.
+This project is incredibly indebted to [gcanti](https://github.com/gcanti),
+[pelotom](https://github.com/pelotom), and the TypeScript community at large.
+There is nothing new in this project, it's all a reimaginings of ideas that
+already existed.
 
-For anyone getting started with functional programming I highly recommend writing your own implementation of an ADT such as Option or Either. From Functor to IndexedTraversable with everything inbetween, there is a lot to learn about the mechanics of programming in general by taking these small pieces apart and putting them back together.
+For anyone getting started with functional programming I highly recommend
+writing your own implementation of an ADT such as Option or Either. From Functor
+to IndexedTraversable with everything inbetween, there is a lot to learn about
+the mechanics of programming in general by taking these small pieces apart and
+putting them back together.
 
 ## Documentation
 
-Deno comes with a documentation generator. The [documentation generation](https://github.com/denoland/deno_doc) doesn't handle re-exports or types on consts that are functions, as that work progresses the documentation for functional will improve. The current documentation for any module at the `HEAD` of the `main` branch can be found here:
+Deno comes with a documentation generator. The
+[documentation generation](https://github.com/denoland/deno_doc) doesn't handle
+re-exports or types on consts that are functions, as that work progresses the
+documentation for functional will improve. The current documentation for any
+module at the `HEAD` of the `main` branch can be found here:
 
 - [Affect](https://doc.deno.land/https/raw.githubusercontent.com%2Fnullpub%2Ffun%2Fmain%2Faffect.ts)
 - [Array](https://doc.deno.land/https/raw.githubusercontent.com%2Fnullpub%2Ffun%2Fmain%2Farray.ts)
@@ -65,7 +107,12 @@ Deno comes with a documentation generator. The [documentation generation](https:
 - [Guard](https://doc.deno.land/https/raw.githubusercontent.com%2Fnullpub%2Ffun%2Fmain%2Fschemable%2Fguard.ts)
 - [Schemable](https://doc.deno.land/https/raw.githubusercontent.com%2Fnullpub%2Ffun%2Fmain%2Fschemable%2Fschemable.ts)
 
-In general, you can take any specific module url and put it into [https://doc.deno.land/](https://doc.deno.land/) to get a decent rendering of the documentation. (Note: Currently the deno_doc crate, which is what doc.deno.land uses, does not handle re-exports or const arrow function exports well. Eventually, the documentation will get better even if this libraries maintainers have to write those patches themselves).
+In general, you can take any specific module url and put it into
+[https://doc.deno.land/](https://doc.deno.land/) to get a decent rendering of
+the documentation. (Note: Currently the deno_doc crate, which is what
+doc.deno.land uses, does not handle re-exports or const arrow function exports
+well. Eventually, the documentation will get better even if this libraries
+maintainers have to write those patches themselves).
 
 ## Versions
 
@@ -75,9 +122,13 @@ In general, you can take any specific module url and put it into [https://doc.de
 
 ## Contributions
 
-Contributions are welcome! Currently, the only maintainer for functional is [baetheus](https://github.com/baetheus). If you want to add to functional or change something, open an issue and ask away. The guidelines for contribution are:
+Contributions are welcome! Currently, the only maintainer for functional is
+[baetheus](https://github.com/baetheus). If you want to add to functional or
+change something, open an issue and ask away. The guidelines for contribution
+are:
 
-1. We use [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
+1. We use
+   [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
 2. We use [semantic versioning](https://semver.org/)
 3. We don't break APIs
 4. We keep test coverage at 100%

--- a/examples/fetch_archives.ts
+++ b/examples/fetch_archives.ts
@@ -1,6 +1,7 @@
 import * as A from "../array.ts";
 import * as D from "../schemable/decoder.ts";
 import * as E from "../either.ts";
+import * as S from "../schemable/schemable.ts";
 import * as TE from "../task_either.ts";
 import * as L from "../optics/lens.ts";
 import * as T from "../optics/traversal.ts";
@@ -37,7 +38,7 @@ const foldErrors = <O>(
 /**
  * Let's make a helper function for fetch. This one takes the same
  * inputs as fetch, but does the following:
- * 
+ *
  * * Wraps fetch in a TaskEither instance
  * * Parses the response to json
  * * Takes any errors and types them as FetchError
@@ -55,11 +56,11 @@ const fetchTaskEither = (
 
 /**
  * Next, let's combine the fetch helper function with a "Decoder"
- * 
+ *
  * A Decoder is simply a function that takes some input and makes
  * sure it has the "shape" or "properties" that we want. It's output
  * is either a tree of errors or the data you want wrapped in an Either.
- * 
+ *
  * Here, we take a decoder, then we return an extension of the
  * fetchTaskEither function where we make sure the response from
  * fetchTaskEither has the structure that we want.
@@ -69,12 +70,15 @@ const fromDecode = <A>(decoder: D.Decoder<A>) =>
   // first argument being a value, it is a function.
   flow(
     fetchTaskEither, // Start with fetchTaskEither
-    TE.chain(flow( // Then take any "good" results and pass them to..
-      decoder, // The decoder
-      E.mapLeft((e) => decodeError(D.draw(e))), // Take any decoder errors and wrap them up
-      TE.fromEither, // Since a decoder returns a plain "Either" we wrap it in a Task to make a TaskEither
-      TE.widen<FetchError>(), // This is necessary so we can have different error types in the flow
-    )),
+    TE.chain(
+      flow(
+        // Then take any "good" results and pass them to..
+        decoder, // The decoder
+        E.mapLeft((e) => decodeError(D.draw(e))), // Take any decoder errors and wrap them up
+        TE.fromEither, // Since a decoder returns a plain "Either" we wrap it in a Task to make a TaskEither
+        TE.widen<FetchError>(), // This is necessary so we can have different error types in the flow
+      ),
+    ),
   );
 
 /**
@@ -82,35 +86,30 @@ const fromDecode = <A>(decoder: D.Decoder<A>) =>
  * for "merging" two decoders together. In this case type contains the required
  * properties on a Document and partial contains the optional ones.
  */
-const Document = pipe(
-  D.struct({
-    title: D.string(),
-    collection: D.array(D.string()), // It's decoders all the way down.
-    downloads: D.number(),
-    format: D.array(D.string()),
-    identifier: D.string(),
-    item_size: D.number(),
-    mediatype: D.string(),
-  }),
-  D.intersect(D.partial({
-    backup_location: D.string(),
-    language: D.string(),
-    date: D.string(),
-    description: pipe(
-      D.string(),
-      D.union(D.array(D.string())),
+const Document = S.make((d) =>
+  pipe(
+    d.struct({
+      title: d.string(),
+      collection: d.array(d.string()), // It's decoders all the way down.
+      downloads: d.number(),
+      format: d.array(d.string()),
+      identifier: d.string(),
+      item_size: d.number(),
+      mediatype: d.string(),
+    }),
+    d.intersect(
+      d.partial({
+        backup_location: d.string(),
+        language: d.string(),
+        date: d.string(),
+        description: pipe(d.string(), d.union(d.array(d.string()))),
+        creator: pipe(d.string(), d.union(d.array(d.string()))),
+        month: d.number(),
+        week: d.number(),
+        year: pipe(d.string(), d.union(d.number())),
+      }),
     ),
-    creator: pipe(
-      D.string(),
-      D.union(D.array(D.string())),
-    ),
-    month: D.number(),
-    week: D.number(),
-    year: pipe(
-      D.string(),
-      D.union(D.number()),
-    ),
-  })),
+  )
 );
 // TypeOf extracts the type from the decoder so
 // we don't have to do double the work keeping decoders
@@ -119,28 +118,34 @@ type Document = D.TypeOf<typeof Document>;
 
 // A response from archive contains many documents and
 // some metadata
-const Response = D.struct({
-  numFound: D.number(),
-  start: D.number(),
-  docs: D.array(Document),
-});
-type Response = D.TypeOf<typeof Response>;
+const Response = S.make((s) =>
+  s.struct({
+    numFound: s.number(),
+    start: s.number(),
+    docs: s.array(Document(s)),
+  })
+);
+type Response = S.TypeOf<typeof Response>;
 
 // The happy path response from archive gives this response
-const QueryResponse = D.struct({
-  response: Response, // Notice that Decoders are composable even when you make your own
-});
-type QueryResponse = D.TypeOf<typeof QueryResponse>;
+const QueryResponse = S.make((s) =>
+  s.struct({
+    response: Response(s), // Notice that Decoders are composable even when you make your own
+  })
+);
+type QueryResponse = S.TypeOf<typeof QueryResponse>;
 
 // Wireup the fromDecode with QueryResponse
-const fetchDecodeArchive = fromDecode(QueryResponse);
+const fetchDecodeArchive = fromDecode(QueryResponse(D.Schemable));
 
 // This is a simple helper function that lets us only worry
 // about supplying a term to lookup in the internet archive
 const queryArchive = (term: string) =>
   fetchDecodeArchive(
     `https://archive.org/advancedsearch.php?q=${
-      encodeURIComponent(term)
+      encodeURIComponent(
+        term,
+      )
     }&output=json`,
   );
 

--- a/fns.ts
+++ b/fns.ts
@@ -4,7 +4,7 @@ import type { Fn, Lazy, Nil, UnknownFn } from "./types.ts";
 
 /**
  * typeOf
- * 
+ *
  * An extended typeOf function that returns "null" for null instead of "object"
  *
  *      const p1 = typeOf(null); // "null"
@@ -25,7 +25,7 @@ export const typeOf = (
 
 /**
  * isNotNil
- * 
+ *
  * Takes a value and returns true if the value is not null or undefined. Also
  * acts as a type guard.
  */
@@ -34,7 +34,7 @@ export const isNotNil = <A>(a: A): a is NonNullable<A> =>
 
 /**
  * isNil
- * 
+ *
  * Takes a value and returns false if the value is not null or undefined. Also
  * acts as a type guard.
  */
@@ -42,7 +42,7 @@ export const isNil = (a: unknown): a is Nil => a === null || a === undefined;
 
 /**
  * isRecord
- * 
+ *
  * Takes a value and returns false if the value is a Record. Also
  * acts as a type guard.
  */
@@ -52,30 +52,30 @@ export const isRecord = (
 
 /**
  * Identity
- * 
+ *
  * Takes a value and returns that same value
  */
 export const identity = <A>(a: A): A => a;
 
 /**
  * Compose
- * 
+ *
  * Takes two functions with matching types and composes them into a new
- * function. 
+ * function.
  */
 export const compose = <B, C>(fbc: Fn<[B], C>) =>
   <A>(fab: Fn<[A], B>): Fn<[A], C> => (a: A): C => fbc(fab(a));
 
 /**
  * Constant
- * 
+ *
  * Creates a constant function around the value a
  */
 export const constant = <A>(a: A): Lazy<A> => () => a;
 
 /**
  * Memoize
- * 
+ *
  * A naive memoization function with no cache release mechanism
  */
 export const memoize = <A, B>(f: (a: A) => B): (a: A) => B => {
@@ -92,7 +92,7 @@ export const memoize = <A, B>(f: (a: A) => B): (a: A) => B => {
 
 /**
  * Intersect
- * 
+ *
  * Takes two types and returns their intersection (if it is possible)
  */
 export const intersect = <A, B>(a: A, b: B): A & B => {
@@ -108,14 +108,14 @@ export const intersect = <A, B>(a: A, b: B): A & B => {
 
 /**
  * HasOwnProperty
- * 
+ *
  * An alias for Object.prototype.hasOwnProperty
  */
 export const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
  * Apply
- * 
+ *
  * Takes a group of arguments and curries them so that a function can be appied
  * to them later (pipeable Function.apply)
  */
@@ -124,7 +124,7 @@ export const apply = <AS extends unknown[], B>(...as: AS) =>
 
 /**
  * Call
- * 
+ *
  * Takes a function and returns that function (pipeable Function.call)
  */
 export const call = <AS extends unknown[], B>(fn: Fn<AS, B>) =>
@@ -132,14 +132,14 @@ export const call = <AS extends unknown[], B>(fn: Fn<AS, B>) =>
 
 /**
  * Apply1
- * 
+ *
  * A special case of apply for functions that only take a single argument
  */
 export const apply1 = <A, B>(a: A, fn: Fn<[A], B>): B => fn(a);
 
 /**
  * Absurd
- * 
+ *
  * A function that should never be called, useful for some theoretical type
  * implementations
  */
@@ -149,14 +149,14 @@ export function absurd<A>(_: never): A {
 
 /**
  * Hole
- * 
+ *
  * The hole const is used for type hole based programming
  */
 export const _: <T>() => T = absurd as any;
 
 /**
  * Wait
- * 
+ *
  * The wait function returns a Promise<void> that resolves after ms milliseconds
  */
 export const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
@@ -195,10 +195,10 @@ export const recover = <A>(fua: (u: unknown) => A) =>
 
 /**
  * Pipe
- * 
+ *
  * The pipe takes a value as the first argument and composes it with subsequent
  * function arguments, returning the result of the last function passed in
- * 
+ *
  * Original pipe function pulled from fp-ts and modified
  * https://github.com/gcanti/fp-ts/blob/master/src/pipeable.ts
  */
@@ -318,10 +318,10 @@ export const pipe: PipeFn = (a: unknown, ...fns: UnknownFn[]): unknown =>
 
 /**
  * Flow
- * 
+ *
  * The flow function is a variadic extension of compose, where each subsequent
  * flow argument is the next function in a compose chain.
- * 
+ *
  * Original flow function pulled from fp-ts and modified
  * https://github.com/gcanti/fp-ts/blob/master/src/functions.ts
  */

--- a/hkt.ts
+++ b/hkt.ts
@@ -1,9 +1,9 @@
 /*******************************************************************************
  * Kinds Type
- * 
+ *
  * A registry for Kind URIS with their substitution strategies. _ represents
  * a tuple of types used to fill a specific Kind.
- * 
+ *
  * Note that the idiomatic replacement type for kinds uses _[0] as the inner-
  * most hole for Functor, Apply, Chain, etc. Thus Either<L, R> should use the
  * hole order of Either<_[1], _[0]>, Reader<R, A> should use Reader<_[1], _[0]>,
@@ -17,7 +17,7 @@ export interface Kinds<_ extends any[]> {
 
 /*******************************************************************************
  * URIS Type
- * 
+ *
  * A union of all Kind URIS, used primarily to ensure that a Kind is registered
  * before it is used to construct an instance.
  ******************************************************************************/
@@ -27,7 +27,7 @@ export type URIS = keyof Kinds<any[]>;
 
 /*******************************************************************************
  * Kind Type
- * 
+ *
  * Lookup the kind at URI and substitute with the values in _.
  ******************************************************************************/
 
@@ -36,7 +36,7 @@ export type Kind<URI extends URIS, _ extends any[] = never[]> = Kinds<_>[URI];
 
 /*******************************************************************************
  * Extraction Types
- * 
+ *
  * Extract the type at a specific index of a Kind type
  ******************************************************************************/
 // deno-lint-ignore no-explicit-any

--- a/nilable.ts
+++ b/nilable.ts
@@ -45,8 +45,7 @@ export const nil: Nil = undefined;
 
 export const constNil = <A = never>(): Nilable<A> => nil;
 
-export const make = <A = never>(a: A): Nilable<A> =>
-  isNotNil(a) ? a : nil;
+export const make = <A = never>(a: A): Nilable<A> => isNotNil(a) ? a : nil;
 
 export const fromPredicate = <A>(predicate: Predicate<A>) =>
   (ta: Nilable<A>): Nilable<A> => isNotNil(ta) && predicate(ta) ? ta : nil;

--- a/option.ts
+++ b/option.ts
@@ -64,7 +64,7 @@ export const constNone = <A = never>(): Option<A> => none;
 /**
  * fromNullable takes a potentially null or undefined value and maps null or undefined to
  * None and non-null and non-undefined values to Some<NonNullable<A>>
- * 
+ *
  * @example
  *     const a: number | undefined = undefined;
  *     const b: number | undefined = 2;
@@ -80,7 +80,7 @@ export const fromNullable = <A>(a: A): Option<NonNullable<A>> =>
  * fromPredicate will test the value a with the predicate. If
  * the predicate evaluates to false then the function will return a None,
  * otherwise the value wrapped in Some
- * 
+ *
  * @example
  *     const fromPositiveNumber = fromPredicate((n: number) => n > 0);
  *     const a = fromPositiveNumber(-1); // None
@@ -113,7 +113,7 @@ export const tryCatch = <A>(f: Lazy<A>): Option<A> => {
  * operator over the two potential cases for an Option type. One supplies functions for
  * handling the Some case and the None case with matching return types and fold calls
  * the correct function for the given option.
- * 
+ *
  * @example
  *     const toNumber = fold((a: number) => a, () => 0);
  *     const a = toNumber(some(1)); // 1
@@ -125,7 +125,7 @@ export const fold = <A, B>(onNone: () => B, onSome: (a: A) => B) =>
 /**
  * getOrElse operates like a simplified fold. One supplies a thunk that returns a default
  * inner value of the Option for the cases where the option is None.
- * 
+ *
  * @example
  *     const toNumber = getOrElse(() => 0);
  *     const a = toNumber(some(1)); // 1
@@ -155,7 +155,7 @@ export const toUndefined = <A>(ma: Option<A>): A | undefined =>
 /**
  * mapNullable is useful for piping an option's values through functions that may return
  * null or undefined.
- * 
+ *
  * @example
  *     const a = pipe(
  *         some([1, 2, 3]),
@@ -272,7 +272,7 @@ export const Traversable: TC.Traversable<URI> = {
 
 /**
  * Generates a Show module for an option with inner type of A.
- * 
+ *
  * @example
  *     const Show = getShow({ show: (n: number) => n.toString() }); // Show<Option<number>>
  *     const a = Show.show(some(1)); // "Some(1)"
@@ -284,7 +284,7 @@ export const getShow = <A>({ show }: TC.Show<A>): TC.Show<Option<A>> => ({
 
 /**
  * Generates a Setoid module for an option with inner type of A.
- * 
+ *
  * @example
  *     const Setoid = getSetoid({ equals: (a: number, b: number) => a === b });
  *     const a = Setoid.equals(some(1), some(2)); // false

--- a/task.ts
+++ b/task.ts
@@ -2,7 +2,7 @@ import type * as HKT from "./hkt.ts";
 import type * as TC from "./type_classes.ts";
 import { Lazy } from "./types.ts";
 
-import { apply, flow, wait, identity } from "./fns.ts";
+import { apply, flow, identity, wait } from "./fns.ts";
 import { createDo } from "./derivations.ts";
 
 /*******************************************************************************

--- a/testing/schemable/decode_error.test.ts
+++ b/testing/schemable/decode_error.test.ts
@@ -143,5 +143,3 @@ Deno.test("DecodeError getSemigroup", () => {
     },
   );
 });
-
-


### PR DESCRIPTION
Update to latest and greatest Schemable

P.s.
I still ended up with quite a huge amount of `deno fmt` related changes. 

```sh
(base) ➜  fun git:(main) deno fmt
/Users/davidpeter/Workspace/playground/fun/hkt.ts
/Users/davidpeter/Workspace/playground/fun/CHANGELOG.md
/Users/davidpeter/Workspace/playground/fun/README.md
/Users/davidpeter/Workspace/playground/fun/testing/schemable/decode_error.test.ts
/Users/davidpeter/Workspace/playground/fun/fns.ts
/Users/davidpeter/Workspace/playground/fun/task.ts
/Users/davidpeter/Workspace/playground/fun/nilable.ts
/Users/davidpeter/Workspace/playground/fun/examples/fetch_archives.ts
/Users/davidpeter/Workspace/playground/fun/option.ts
Checked 92 files
```