### PR TITLE
fix: correct type for schemable > nullable

### DIFF
--- a/examples/schemable.ts
+++ b/examples/schemable.ts
@@ -12,8 +12,10 @@ export const Demo = S.make((s) =>
     two: s.partial({
       three: s.string(),
       four: s.literal(1, 2),
+      five: s.nullable(s.string()),
     }),
     things: Thing(s),
+    maybeNull: s.nullable(s.string()),
   })
 );
 export type Demo = S.TypeOf<typeof Demo>;

--- a/schemable/schemable.ts
+++ b/schemable/schemable.ts
@@ -2,15 +2,15 @@ import type { Kind, URIS } from "../hkt.ts";
 
 import { memoize } from "../fns.ts";
 
-/*******************************************************************************
+/** *****************************************************************************
  * Types
- ******************************************************************************/
+ * **************************************************************************** */
 
 export type Literal = string | number | boolean | null;
 
-/*******************************************************************************
+/** *****************************************************************************
  * Schemable Type Class
- ******************************************************************************/
+ * **************************************************************************** */
 
 export type UnknownSchemable<URI extends URIS> = {
   readonly unknown: <B = never, C = never, D = never>() => Kind<
@@ -54,7 +54,7 @@ export type LiteralSchemable<URI extends URIS> = {
 export type NullableSchemable<URI extends URIS> = {
   readonly nullable: <A, B = never, C = never, D = never>(
     or: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [A | null, B | null, C, D]>;
+  ) => Kind<URI, [A | null, B, C, D]>;
 };
 
 export type UndefinableSchemable<URI extends URIS> = {
@@ -138,9 +138,9 @@ export type Schema<A, B = never, C = never, D = never> = <URI extends URIS>(
 
 export type TypeOf<T> = T extends Schema<infer A> ? A : never;
 
-/*******************************************************************************
+/** *****************************************************************************
  * Utilities
- ******************************************************************************/
+ * **************************************************************************** */
 
 export const make = <A, B = never, C = never, D = never>(
   f: (s: Schemable<URIS>) => Kind<URIS, [A, B, C, D]>,


### PR DESCRIPTION
The NullableSchemable type in schemable.ts had set the second generic
in its Kind return value to `B | null`. This type is incorrect as it
assumes that the second parameter of the replacement type must be null.
For example, NullableSchemable for a Decoder might have the type
`type numToStrDecode = Decoder<number, string>`. Applying the nullable
schemable to this decoder would result in the erroneous type
`Decoder<number | null, string | null>`. The fix is to remove the union
with null from the output second parameter of NullableSchemable.

Fixes #26