### PR TITLE
fix(task_either): tryCatch should take a Task<A>

### DIFF
--- a/task_either.ts
+++ b/task_either.ts
@@ -21,7 +21,7 @@ import {
   of as taskOf,
 } from "./task.ts";
 import { createDo } from "./derivations.ts";
-import { flow, handleThrow, identity, pipe, resolve, then } from "./fns.ts";
+import { flow, handleThrow, identity, pipe, resolve } from "./fns.ts";
 
 export type TaskEither<L, R> = Task<Either<L, R>>;
 
@@ -50,7 +50,7 @@ export function tryCatch<A, B>(
 ): TaskEither<B, A> {
   return handleThrow(
     fa,
-    then(eitherRight),
+    flow((a) => a.then(eitherRight).catch(flow(onError, eitherLeft))),
     flow(onError, (b) => eitherLeft<B, A>(b), resolve),
   );
 }

--- a/task_either.ts
+++ b/task_either.ts
@@ -21,7 +21,7 @@ import {
   of as taskOf,
 } from "./task.ts";
 import { createDo } from "./derivations.ts";
-import { flow, handleThrow, identity, pipe, resolve } from "./fns.ts";
+import { flow, handleThrow, identity, pipe, resolve, then } from "./fns.ts";
 
 export type TaskEither<L, R> = Task<Either<L, R>>;
 
@@ -45,12 +45,12 @@ export function right<A = never, B = never>(right: A): TaskEither<B, A> {
 }
 
 export function tryCatch<A, B>(
-  fa: () => A,
+  fa: Task<A>,
   onError: (e: unknown) => B,
 ): TaskEither<B, A> {
   return handleThrow(
     fa,
-    flow((a) => eitherRight<B, A>(a), resolve),
+    then(eitherRight),
     flow(onError, (b) => eitherLeft<B, A>(b), resolve),
   );
 }

--- a/testing/task_either.test.ts
+++ b/testing/task_either.test.ts
@@ -23,13 +23,21 @@ Deno.test("TaskEither right", async () => {
 Deno.test("TaskEither tryCatch", async (t) => {
   await t.step("Sync", async () => {
     await assertEqualsT(T.tryCatch(_, () => "Bad"), T.left("Bad"));
-    await assertEqualsT(T.tryCatch(() => { throw new Error('Boom') }, () => "Bad"), T.left("Bad"));
+    await assertEqualsT(
+      T.tryCatch(() => {
+        throw new Error("Boom");
+      }, () => "Bad"),
+      T.left("Bad"),
+    );
     await assertEqualsT(T.tryCatch(() => resolve(1), String), T.right(1));
     await assertEqualsT(T.tryCatch(taskOf(1), String), T.right(1));
   });
   await t.step("Async", async () => {
     await assertEqualsT(T.tryCatch(async () => await 1, String), T.right(1));
-    await assertEqualsT(T.tryCatch(async () => await resolve(1), String), T.right(1));
+    await assertEqualsT(
+      T.tryCatch(async () => await resolve(1), String),
+      T.right(1),
+    );
     await assertEqualsT(
       T.tryCatch(() => {
         throw new Error("boom");

--- a/testing/task_either.test.ts
+++ b/testing/task_either.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 
 import * as T from "../task_either.ts";
 import * as E from "../either.ts";
-import { _, pipe, then } from "../fns.ts";
+import { _, pipe, resolve, then } from "../fns.ts";
 
 import * as AS from "./assert.ts";
 
@@ -21,7 +21,7 @@ Deno.test("TaskEither right", async () => {
 
 Deno.test("TaskEither tryCatch", async () => {
   await assertEqualsT(T.tryCatch(_, () => "Bad"), T.left("Bad"));
-  await assertEqualsT(T.tryCatch(() => 1, String), T.right(1));
+  await assertEqualsT(T.tryCatch(() => resolve(1), String), T.right(1));
 });
 
 Deno.test("TaskEither fromFailableTask", async () => {


### PR DESCRIPTION
This change is required, so the result of calling `tryCatch` with an `async` function correctly evaluate to `Task<Either<L,R>>` and not `Task<Either<L, Promise<R>>`