### PR TITLE
feat: allow the 2nd function of fns/compose to take multi arguments

### DIFF
--- a/fns.ts
+++ b/fns.ts
@@ -95,8 +95,8 @@ export function identity<A>(a: A): A {
  */
 export function compose<B, C>(
   fbc: Fn<[B], C>,
-): <A>(fab: Fn<[A], B>) => Fn<[A], C> {
-  return (fab) => (a) => fbc(fab(a));
+): <A extends unknown[]>(fab: Fn<A, B>) => Fn<A, C> {
+  return (fab) => (...args) => fbc(fab(...args));
 }
 
 /**

--- a/testing/fns.test.ts
+++ b/testing/fns.test.ts
@@ -5,6 +5,7 @@ import {
 } from "https://deno.land/std/testing/asserts.ts";
 
 import * as F from "../fns.ts";
+import { zip } from "../array.ts";
 
 Deno.test("fns isNotNil", () => {
   assertEquals(F.isNotNil(undefined), false);
@@ -43,6 +44,22 @@ Deno.test("fns compose", () => {
   const comp0 = F.compose(fab);
   const comp1 = comp0(fab);
   assertEquals(comp1(1), 3);
+
+  const comp2 = comp0(parseInt);
+  assertEquals(comp2("ff", 16), 256);
+
+  const template = (add: number) =>
+    (
+      [start, ...segments]: TemplateStringsArray,
+      ...numbers: number[]
+    ): string =>
+      [
+        start,
+        ...zip(segments)(numbers)
+          .map(([number, segment]) => `${number + add}${segment}`),
+      ].join("");
+  const repeated = F.flow(template, F.compose((a) => [a, a]));
+  assertEquals(repeated(1)`a${2}b${3}`, ["a3b4", "a3b4"]);
 });
 
 Deno.test("fns swap", () => {


### PR DESCRIPTION
I’m proposing a slightly modified interface and implementation for `fns/compose`:

```
export function compose<B, C>(
  fbc: Fn<[B], C>,
): <A extends unknown[]>(fab: Fn<A, B>) => Fn<A, C> {
  return (fab) => (...args) => fbc(fab(...args));
}
```

The reason behind is that the `fab` I’m dealing with is a string template function:

```
(template: TemplateStringsArray, ...args: postgres.SerializableParameter[])
```

Functions such as `parseInt` also benefit from the modified interface.

Please let me know if more rational approaches exist. Thank you.