### PR TITLE
feat: ord/{fromCompare, createOrdTuple, contramap}

### DIFF
--- a/array.ts
+++ b/array.ts
@@ -6,7 +6,7 @@ import * as O from "./option.ts";
 import { createDo } from "./derivations.ts";
 import { apply, flow, identity, pipe } from "./fns.ts";
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
-import { compare, Ord } from "./ord.ts";
+import { Ord, toCompare } from "./ord.ts";
 
 export type TypeOf<T> = T extends ReadonlyArray<infer A> ? A : never;
 
@@ -362,7 +362,7 @@ export const unzip = <A, B>(
 export function sort<B>(
   O: Ord<B>,
 ): <A extends B>(as: ReadonlyArray<A>) => ReadonlyArray<B> {
-  const _compare = compare(O);
+  const _compare = toCompare(O);
   return (as) => as.slice().sort(_compare);
 }
 

--- a/map.ts
+++ b/map.ts
@@ -4,7 +4,7 @@ import type * as T from "./types.ts";
 
 import * as O from "./option.ts";
 import * as A from "./array.ts";
-import { compare } from "./ord.ts";
+import { toCompare } from "./ord.ts";
 import { fromEquals } from "./setoid.ts";
 import { flow, pipe } from "./fns.ts";
 
@@ -129,18 +129,18 @@ export function elem<A>(
 export function entries<B>(
   O: T.Ord<B>,
 ): (<A>(ta: Map<B, A>) => ReadonlyArray<[B, A]>) {
-  const _compare = compare(O);
+  const _compare = toCompare(O);
   return (ta) =>
     Array.from(ta.entries()).sort(([left], [right]) => _compare(left, right));
 }
 
 export function keys<K>(O: T.Ord<K>): (<A>(ta: Map<K, A>) => K[]) {
-  const _compare = compare(O);
+  const _compare = toCompare(O);
   return (ta) => Array.from(ta.keys()).sort(_compare);
 }
 
 export function values<A>(O: T.Ord<A>): (<K>(ta: Map<K, A>) => A[]) {
-  const _compare = compare(O);
+  const _compare = toCompare(O);
   return (ta) => Array.from(ta.values()).sort(_compare);
 }
 

--- a/record.ts
+++ b/record.ts
@@ -3,7 +3,7 @@ import type * as T from "./types.ts";
 import type { Fn } from "./types.ts";
 
 import { hasOwnProperty, pipe } from "./fns.ts";
-import { compare, ordString } from "./ord.ts";
+import { ordString, toCompare } from "./ord.ts";
 
 export type ReadonlyRecord<V> = Readonly<Record<string, V>>;
 
@@ -18,7 +18,7 @@ declare module "./kind.ts" {
   }
 }
 
-const compareStrings = compare(ordString);
+const compareStrings = toCompare(ordString);
 
 const sortStrings = (keys: string[]): string[] => keys.sort(compareStrings);
 

--- a/testing/ord.test.ts
+++ b/testing/ord.test.ts
@@ -19,8 +19,8 @@ Deno.test("Ord ordBoolean", () => {
   AS.assertOrd(O.ordBoolean, { a: true, b: false });
 });
 
-Deno.test("Ord compare", () => {
-  const compare = O.compare(O.ordNumber);
+Deno.test("Ord toCompare", () => {
+  const compare = O.toCompare(O.ordNumber);
   assertEquals(typeof compare, "function");
   assertEquals(compare(0, 0), 0);
   assertEquals(compare(0, 1), -1);
@@ -97,4 +97,38 @@ Deno.test("Ord between", () => {
 
 Deno.test("Ord getOrdUtilities", () => {
   assertExists(O.getOrdUtilities(O.ordNumber));
+});
+
+Deno.test("Ord fromCompare", () => {
+  const compareFoo: O.Compare<{ foo: string }> = (a, b) =>
+    O.toCompare(O.ordString)(a.foo, b.foo);
+  const a = { foo: "bar" };
+  const b = { foo: "bar" };
+  const c = { foo: "baz" };
+
+  const ordFoo = O.fromCompare(compareFoo);
+
+  assertEquals(ordFoo.equals(a)(a), true);
+  assertEquals(ordFoo.equals(a)(b), true);
+  assertEquals(ordFoo.equals(a)(c), false);
+  assertEquals(ordFoo.lte(c)(b), true);
+  assertEquals(ordFoo.lte(b)(c), false);
+});
+
+Deno.test("Ord createOrdTuple", () => {
+  const ordTuple = O.createOrdTuple(O.ordString, O.ordNumber);
+
+  assertEquals(O.toCompare(ordTuple)(["y", 1], ["z", 1]), -1);
+  assertEquals(O.toCompare(ordTuple)(["y", 1], ["y", 2]), -1);
+  assertEquals(O.toCompare(ordTuple)(["y", 1], ["y", 1]), 0);
+  assertEquals(O.toCompare(ordTuple)(["y", 1], ["y", 0]), 1);
+  assertEquals(O.toCompare(ordTuple)(["y", 1], ["x", 1]), 1);
+});
+
+Deno.test("Ord contramap", () => {
+  const ordFoo = O.contramap((foo: { foo: number }) => foo.foo)(O.ordNumber);
+
+  assertEquals(O.toCompare(ordFoo)({ foo: 1 }, { foo: 0 }), 1);
+  assertEquals(O.toCompare(ordFoo)({ foo: 1 }, { foo: 1 }), 0);
+  assertEquals(O.toCompare(ordFoo)({ foo: 1 }, { foo: 2 }), -1);
 });


### PR DESCRIPTION
This PR introduces 3 functions to the `Ord` algebraic structure:

- `fromCompare`, which derives an `Ord` instance from a `compare` function for the same type.
- `createOrdTuple`, which derives an `Ord` instance for tuple type using a tuple of `Ord` instances.
- `contramap`, which derives an instance of `Ord<A>` using a function from `A` to `B` and an instance of `Ord<B>`.

`compare` is renamed to `toCompare` to form a `from/to` pair.

Thanks.